### PR TITLE
[Trivial] Fix a H1 title in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ stdin 45
 133
 ```
 
-#Server
+# Server
 The server must be running for the DCD client to provide autocomplete information.
 In future versions the client may start the server if it is not running, but for
 now it must be started manually or (usually) by an editor plugin.


### PR DESCRIPTION
Used to be okay i nthe past but GH doesn't render them anymore